### PR TITLE
Adds `certs/ca-bundle.crt` to POSIX path

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,6 +62,7 @@ pub fn probe() -> ProbeResult {
             "certs.pem",
             "certs/ca-certificates.crt",
             "certs/ca-root-nss.crt"
+            "certs/ca-bundle.crt"
         ].iter() {
             try(&mut result.cert_file, certs_dir.join(cert));
         }


### PR DESCRIPTION
This resolves issue #1978 on rust-lang for Fedora packaged instances of OpenSSL