### PR TITLE
Add path probing for modern RHEL-based systems

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "openssl-probe"
-version = "0.1.1"
+version = "0.1.2"
 authors = ["Alex Crichton <alex@alexcrichton.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/openssl-probe"

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ First, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-openssl-probe = "0.1.1"
+openssl-probe = "0.1.2"
 ```
 
 Then add this to your crate:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@ pub fn find_certs_dirs() -> Vec<PathBuf> {
         "/usr/lib/ssl",
         "/usr/ssl",
         "/etc/openssl",
+        "/etc/pki/ca-trust/extracted/pem",
         "/etc/pki/tls",
         "/etc/ssl",
         "/data/data/com.termux/files/usr/etc/tls",
@@ -66,6 +67,7 @@ pub fn probe() -> ProbeResult {
             "certs/ca-root-nss.crt",
             "certs/ca-bundle.crt",
             "CARootCertificates.pem",
+            "tls-ca-bundle.pem",
         ].iter() {
             try(&mut result.cert_file, certs_dir.join(cert));
         }


### PR DESCRIPTION
On these systems `/etc/pki/tls/certs/ca-bundle.crt` is provided as a legacy mechanism and isn't updated with system-wide installed roots by default. This behavior can be changed by running `update-ca-trust
enable` but it would be better to just use the correct path. See https://www.unix.com/man-page/centos/8/update-ca-trust/ for details.

Note that the legacy path still exists, so the new path needs to come before it in the search order.