### PR TITLE
Fix use after move error introduced in new Rust version

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,12 +48,12 @@ pub fn find_certs_dirs() -> Vec<PathBuf> {
 /// variables are valid.
 pub fn init_ssl_cert_env_vars() -> bool {
     let ProbeResult { cert_file, cert_dir } = probe();
-    match cert_file {
-        Some(path) => put(ENV_CERT_FILE, path),
+    match &cert_file {
+        Some(path) => put(ENV_CERT_FILE, path.to_path_buf()),
         None => {}
     }
-    match cert_dir {
-        Some(path) => put(ENV_CERT_DIR, path),
+    match &cert_dir {
+        Some(path) => put(ENV_CERT_DIR, path.to_path_buf()),
         None => {}
     }
 


### PR DESCRIPTION
Apparently, the following two use-after-move problems were introduced when compiling with newer Rust versions:

```
error[E0382]: use of partially moved value: `cert_file`
  --> src/lib.rs:68:5
   |
52 |         Some(path) => put(ENV_CERT_FILE, path),
   |              ---- value moved here
...
68 |     cert_file.is_some() || cert_dir.is_some()
   |     ^^^^^^^^^ value used here after move
   |
   = note: move occurs because the value has type `std::path::PathBuf`, which does not implement the `Copy` trait

error[E0382]: use of partially moved value: `cert_dir`
  --> src/lib.rs:68:28
   |
56 |         Some(path) => put(ENV_CERT_DIR, path),
   |              ---- value moved here
...
68 |     cert_file.is_some() || cert_dir.is_some()
   |                            ^^^^^^^^ value used here after move
   |
   = note: move occurs because the value has type `std::path::PathBuf`, which does not implement the `Copy` trait
```

This PR fixes these issues.