### PR TITLE
openSUSE has a ca-bundle.pem

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,6 +95,7 @@ pub fn probe() -> ProbeResult {
         for cert in [
             "cert.pem",
             "certs.pem",
+            "ca-bundle.pem",
             "certs/ca-certificates.crt",
             "certs/ca-root-nss.crt",
             "certs/ca-bundle.crt",


### PR DESCRIPTION
In openSUSE the ca-bundle is installed via symlink at /etc/ssl/ca-bundle.pem