### PR TITLE
Security: reduce paths inspected on common OSes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ fn cert_dirs_iter() -> impl Iterator<Item = &'static Path> {
         "/etc/ssl",
         "/etc/certs",
         "/opt/etc/ssl", // Entware
+        #[cfg(target_os = "android")]
         "/data/data/com.termux/files/usr/etc/tls",
         #[cfg(target_os = "haiku")]
         "/boot/system/data/ssl",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ fn cert_dirs_iter() -> impl Iterator<Item = &'static Path> {
         "/etc/certs",
         "/opt/etc/ssl", // Entware
         "/data/data/com.termux/files/usr/etc/tls",
+        #[cfg(target_os = "haiku")]
         "/boot/system/data/ssl",
     ]
     .iter().map(Path::new).filter(|p| p.exists())


### PR DESCRIPTION
The changes in #2 and #4 are pretty esoteric and inappropriate for most users. This PR compiles them out based on `target_os`.

Most importantly, nothing really guarantees that `/data` is a good place for look for anything on a common OS. In the security report we received yesterday against `rustls-native-certs` (which uses this crate), it was theorized that a rust binary running in a minimal docker image that operates on untrusted input mounted into `/data` would be tricked into trusting root certs included in the untrusted data. That is both surprising and very bad.

The haiku case is marginal because `/boot` is at least blessed in [FHS](https://refspecs.linuxfoundation.org/fhs.shtml). However I think this list of search paths should be minimal, since it is security sensitive for much of the rust ecosystem.