### PR TITLE
Add 0.2.0 where unsafe features are feature-flagged with scary warning

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "openssl-probe"
-version = "0.1.6"
-authors = ["Alex Crichton <alex@alexcrichton.com>"]
+version = "0.2.0"
+authors = ["Alex Crichton <alex@alexcrichton.com>", "Matt Mastracci <matthew@mastracci.com>"]
 license = "MIT/Apache-2.0"
 repository = "https://github.com/alexcrichton/openssl-probe"
 homepage = "https://github.com/alexcrichton/openssl-probe"
@@ -14,3 +14,13 @@ edition = '2021'
 # This was arbitrarily chosen on 2025-01-23 as "pretty old" as previously
 # key didn't exist in `Cargo.toml` prior to that.
 rust-version = '1.60.0'
+
+[features]
+# WARNING: Features behind this flag are likely not sound unless 1) you are
+# performing these actions at the start of your main function, or 2) you are
+# absolutely certain no non-Rust threads are active. Enabling this feature
+# may result in difficult-to-diagnose crashes.
+allow-unsafe-set-env = []
+
+[package.metadata.docs.rs]
+all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,8 +18,9 @@ rust-version = '1.60.0'
 [features]
 # WARNING: Features behind this flag are likely not sound unless 1) you are
 # performing these actions at the start of your main function, or 2) you are
-# absolutely certain no non-Rust threads are active. Enabling this feature
-# may result in difficult-to-diagnose crashes.
+# otherwise absolutely certain that you are running in a single-threaded
+# environment. Enabling this feature may result in difficult-to-diagnose crashes
+# in code running in other crates.
 allow-unsafe-set-env = []
 
 [package.metadata.docs.rs]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,12 +43,6 @@ pub fn candidate_cert_dirs() -> impl Iterator<Item = &'static Path> {
     .filter(|p| p.exists())
 }
 
-#[cfg(feature = "allow-unsafe-set-env")]
-/// WARNING: This method is likely not safe to use, unless 1) you are
-/// performing these actions at the start of your main function, or 2) you are
-/// otherwise absolutely certain that you are running in a single-threaded
-/// environment.
-/// 
 /// Probe for SSL certificates on the system, then configure the SSL certificate `SSL_CERT_FILE`
 /// and `SSL_CERT_DIR` environment variables in this process for OpenSSL to use.
 ///
@@ -56,6 +50,12 @@ pub fn candidate_cert_dirs() -> impl Iterator<Item = &'static Path> {
 /// point to exist and are accessible.
 ///
 /// # Safety
+///
+/// <div class="danger">Use of this method in multi-threaded
+/// environments is unsound. You should not use it unless 1) you
+/// are performing these actions at the start of your main function, or 2) you
+/// are otherwise absolutely certain that you are running in a single-threaded
+/// environment.</div>
 ///
 /// This function is not safe because it mutates the process's environment
 /// variables which is generally not safe. See the [documentation in libstd][doc]
@@ -65,36 +65,40 @@ pub fn candidate_cert_dirs() -> impl Iterator<Item = &'static Path> {
 /// methods instead of relying on environment variables.
 ///
 /// [doc]: https://doc.rust-lang.org/stable/std/env/fn.set_var.html#safety
+#[cfg(feature = "allow-unsafe-set-env")]
 pub unsafe fn init_openssl_env_vars() {
     try_init_openssl_env_vars();
 }
 
-#[cfg(feature = "allow-unsafe-set-env")]
-/// WARNING: This method is likely not safe to use, unless 1) you are
-/// performing these actions at the start of your main function, or 2) you are
-/// otherwise absolutely certain that you are running in a single-threaded
-/// environment.
-/// 
-/// Probe for SSL certificates on the system, then configure the SSL certificate `SSL_CERT_FILE`
-/// and `SSL_CERT_DIR` environment variables in this process for OpenSSL to use.
+/// Probe for SSL certificates on the system, then configure the SSL certificate
+/// `SSL_CERT_FILE` and `SSL_CERT_DIR` environment variables in this process for
+/// OpenSSL to use.
 ///
-/// Preconfigured values in the environment variables will not be overwritten if the paths they
-/// point to exist and are accessible.
+/// Preconfigured values in the environment variables will not be overwritten if
+/// the paths they point to exist and are accessible.
 ///
 /// Returns `true` if any certificate file or directory was found while probing.
-/// Combine this with `has_ssl_cert_env_vars()` to check whether previously configured environment
-/// variables are valid.
+/// Combine this with `has_ssl_cert_env_vars()` to check whether previously
+/// configured environment variables are valid.
 ///
 /// # Safety
 ///
+/// <div class="danger">Use of this method in multi-threaded
+/// environments is unsound. You should not use it unless 1) you
+/// are performing these actions at the start of your main function, or 2) you
+/// are otherwise absolutely certain that you are running in a single-threaded
+/// environment.</div>
+/// 
 /// This function is not safe because it mutates the process's environment
-/// variables which is generally not safe. See the [documentation in libstd][doc]
-/// for information about why setting environment variables is not safe.
+/// variables which is generally not safe. See the [documentation in
+/// libstd][doc] for information about why setting environment variables is not
+/// safe.
 ///
 /// If possible use the [`probe`] function and directly configure OpenSSL
 /// methods instead of relying on environment variables.
 ///
 /// [doc]: https://doc.rust-lang.org/stable/std/env/fn.set_var.html#safety
+#[cfg(feature = "allow-unsafe-set-env")]
 pub unsafe fn try_init_openssl_env_vars() -> bool {
     let ProbeResult {
         cert_file,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,6 +44,11 @@ pub fn candidate_cert_dirs() -> impl Iterator<Item = &'static Path> {
 }
 
 #[cfg(feature = "allow-unsafe-set-env")]
+/// WARNING: This method is likely not safe to use, unless 1) you are
+/// performing these actions at the start of your main function, or 2) you are
+/// otherwise absolutely certain that you are running in a single-threaded
+/// environment.
+/// 
 /// Probe for SSL certificates on the system, then configure the SSL certificate `SSL_CERT_FILE`
 /// and `SSL_CERT_DIR` environment variables in this process for OpenSSL to use.
 ///
@@ -65,6 +70,11 @@ pub unsafe fn init_openssl_env_vars() {
 }
 
 #[cfg(feature = "allow-unsafe-set-env")]
+/// WARNING: This method is likely not safe to use, unless 1) you are
+/// performing these actions at the start of your main function, or 2) you are
+/// otherwise absolutely certain that you are running in a single-threaded
+/// environment.
+/// 
 /// Probe for SSL certificates on the system, then configure the SSL certificate `SSL_CERT_FILE`
 /// and `SSL_CERT_DIR` environment variables in this process for OpenSSL to use.
 ///


### PR DESCRIPTION
One downstream crate unfortunately ignored the safety warning on the environment setter methods, which means it's just as likely to crash as before.

This removes all old deprecated methods and puts the new methods behind a feature flag with an appropriate safety warning. The RUSTSEC advisory can then be extended to all crates < 0.2.0.

This may result in some semver-related `Cargo.lock` crate duplication, but with luck it should filter out into the ecosystem relatively quickly.