### PR TITLE
feat: add openharmony platform preset certs folder

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,6 +47,8 @@ pub fn candidate_cert_dirs() -> impl Iterator<Item = &'static Path> {
         "/data/data/com.termux/files/usr/etc/tls",
         #[cfg(target_os = "haiku")]
         "/boot/system/data/ssl",
+        #[cfg(target_env = "ohos")]
+        "/etc/security/certificates",
     ]
     .iter()
     .map(Path::new)


### PR DESCRIPTION
According to the latest document https://developer.huawei.com/consumer/en/doc/best-practices/bpta-network-ca-security#section121091116142117 , we need to add the preset folder for OpenHarmony. And follow the https://github.com/sfackler/rust-native-tls/pull/297/files

Also close #29 