### PR TITLE
Update certificate dirs and file names on FreeBSD

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,10 +140,14 @@ const CERTIFICATE_DIRS: &[&str] = &[
     "/etc/pki/tls/certs", // Fedora, RHEL
 ];
 
+// `*/etc/ssl/certs` is the default TRUSTDESTDIR (15+)/CERTDESTDIR (<15) for `certctl(8)`
+// `/usr/local/openssl/certs` is used for OpenSSL from ports
+// https://man.freebsd.org/cgi/man.cgi?query=certctl&sektion=8
 #[cfg(target_os = "freebsd")]
 const CERTIFICATE_DIRS: &[&str] = &[
-    "/etc/ssl/certs",         // FreeBSD 12.2+,
-    "/usr/local/share/certs", // FreeBSD
+    "/etc/ssl/certs",
+    "/usr/local/etc/ssl/certs",
+    "/usr/local/openssl/certs",
 ];
 
 #[cfg(any(target_os = "illumos", target_os = "solaris"))]
@@ -176,8 +180,17 @@ const CERTIFICATE_FILE_NAMES: &[&str] = &[
     "/opt/etc/ssl/certs/ca-certificates.crt", // Entware, https://github.com/rustls/openssl-probe/pull/21
 ];
 
+// `*/etc/ssl/cert.pem` is the default BUNDLE (15+) for `certctl(8)`
+// `/usr/local/openssl/cert.pem` is used for OpenSSL from ports
+// `/usr/local/share/certs/ca-root-nss.crt` is from ca_root_nss from ports
+// https://man.freebsd.org/cgi/man.cgi?query=certctl&sektion=8
 #[cfg(target_os = "freebsd")]
-const CERTIFICATE_FILE_NAMES: &[&str] = &["/usr/local/etc/ssl/cert.pem"];
+const CERTIFICATE_FILE_NAMES: &[&str] = &[
+    "/etc/ssl/cert.pem",
+    "/usr/local/etc/ssl/cert.pem",
+    "/usr/local/openssl/cert.pem",
+    "/usr/local/share/certs/ca-root-nss.crt",
+];
 
 #[cfg(target_os = "dragonfly")]
 const CERTIFICATE_FILE_NAMES: &[&str] = &["/usr/local/share/certs/ca-root-nss.crt"];


### PR DESCRIPTION
FreeBSD contains a canonical certstore managed by certctl(8) since 12.2 located in the base system (/etc/ssl), search there first. Alternatively, a user can populate a custom store in distbase (/usr/local/etc/ssl) with certctl(8) which shall be queried if the former does not exist. At last, there is a store for OpenSSL from the ports (/usr/local/openssl) outside of certctl(8)'s reach. Within these there can be also a bundle in parallel to a hashed directory.

This fixes #20 and fixes #37
---

FreeBSD port maintainer here.

Improvement on top of @djc's work: `certctl(8)`'s introduction on FreeBSD 12.2 make life much easier. `CERTIFICATE_DIRS` uses those two from it. Additionally from `security/openssl*`. `/usr/local/share/certs` is a source for `certlctl(8)` which ends up in either of them, thus would lead to duplicates. Extended `CERTIFICATE_FILE_NAMES` by those files created by `certctl(8)` from FreeBSD 15+ or ultimately for those who still install `security/ca_root_nss` which is included in `/usr/share/certs/trusted` anyway.

Sample code:
```rust
use openssl_probe::probe;
use curl::easy::Easy;

fn main() {
    let result = probe();

    match result.cert_file {
        Some(ref path) => println!("result.cert_file: {}", path.display()),
        None => println!("result.cert_file: None"),
    }

    if result.cert_dir.is_empty() {
        println!("result.cert_dir: None");
    } else {
        for path in &result.cert_dir {
            println!("result.cert_dir: {}", path.display());
        }
    }

 let mut data = Vec::new();
 let mut handle = Easy::new();
 handle.url("https://dw-eng-rsc.innomotics.net/").unwrap();
 {
     let mut transfer = handle.transfer();
     transfer.write_function(|new_data| {
         data.extend_from_slice(new_data);
         Ok(new_data.len())
     }).unwrap();
     transfer.perform().unwrap();
 }
}
```

Verification in a standalone application while removing and adding potential candidates:
```
cafe-custom-uis@deblndw013x3j:/usr/home/cafe-custom-uis/openssl-probe-tester
$ ./target/debug/openssl-probe-tester
result.cert_file: /etc/ssl/cert.pem
result.cert_dir: /etc/ssl/certs
cafe-custom-uis@deblndw013x3j:/usr/home/cafe-custom-uis/openssl-probe-tester
$ ./target/debug/openssl-probe-tester
result.cert_file: /usr/local/etc/ssl/cert.pem
result.cert_dir: /etc/ssl/certs
cafe-custom-uis@deblndw013x3j:/usr/home/cafe-custom-uis/openssl-probe-tester
$ ./target/debug/openssl-probe-tester
result.cert_file: /usr/local/share/certs/ca-root-nss.crt
result.cert_dir: /etc/ssl/certs
cafe-custom-uis@deblndw013x3j:/usr/home/cafe-custom-uis/openssl-probe-tester
$ vim ./target/debug/openssl-probe-tester
cafe-custom-uis@deblndw013x3j:/usr/home/cafe-custom-uis/openssl-probe-tester
$ vim src/main.rs
cafe-custom-uis@deblndw013x3j:/usr/home/cafe-custom-uis/openssl-probe-tester
$ ./target/debug/openssl-probe-tester
result.cert_file: None
result.cert_dir: /etc/ssl/certs
cafe-custom-uis@deblndw013x3j:/usr/home/cafe-custom-uis/openssl-probe-tester
$ ./target/debug/openssl-probe-tester
result.cert_file: None
result.cert_dir: /etc/ssl/certs
cafe-custom-uis@deblndw013x3j:/usr/home/cafe-custom-uis/openssl-probe-tester
$ ./target/debug/openssl-probe-tester
result.cert_file: None
result.cert_dir: None

thread 'main' (189247) panicked at src/main.rs:29:25:
called `Result::unwrap()` on an `Err` value: Error { description: "SSL peer certificate or SSH remote key was not OK", code: 60, extra: Some("SSL certificate OpenSSL verify result: unable to get local issuer certificate (20)") }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
cafe-custom-uis@deblndw013x3j:/usr/home/cafe-custom-uis/openssl-probe-tester
$ ./target/debug/openssl-probe-tester
result.cert_file: None
result.cert_dir: /etc/ssl/certs
```
Running against publically available servers as well as in-house with enterprise CA structure.