### PR TITLE
docs: clarify lib description, update README

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,8 @@ license = "MIT OR Apache-2.0"
 repository = "https://github.com/rustls/openssl-probe"
 homepage = "https://github.com/rustls/openssl-probe"
 description = """
-Tool for helping to find SSL certificate locations on the system for OpenSSL
+A library for helping to find system-wide trust anchor ("root") certificate
+locations based on paths typically used by `openssl`.
 """
 readme = "README.md"
 edition = '2021'

--- a/README.md
+++ b/README.md
@@ -1,20 +1,19 @@
 # openssl-probe
 
-Tool for helping to find SSL certificate locations on the system for OpenSSL
+A library for helping to find system-wide trust anchor ("root") certificate
+locations based on paths typically used by `openssl`.
+
+For most users, [`rustls-platform-verifier`][] or [`rustls-native-certs`][]
+are more convenient and robust ways to have TLS connections respect system
+configuration. This is a lower-level library.
 
 [![Crates.io](https://img.shields.io/crates/v/openssl-probe.svg?maxAge=2592000)](https://crates.io/crates/openssl-probe)
 [![docs.rs](https://docs.rs/openssl-probe/badge.svg)](https://docs.rs/openssl-probe/)
 
+[`rustls-platform-verifier`]: https://crates.io/crates/rustls-platform-verifier
+[`rustls-native-certs`]: https://crates.io/crates/rustls-native-certs
+
 ## Usage
-
-First, add this to your `Cargo.toml`:
-
-```toml
-[dependencies]
-openssl-probe = "0.1.6"
-```
-
-Then add this to your crate:
 
 ```rust
 fn main() {


### PR DESCRIPTION
It's a lib, not a tool, and we don't typically use it for OpenSSL, but rather other crates trying to emulate OpenSSL's behavior.

We also don't need to help guide through adding a dependency to a Rust project. Most users shouldn't be touching this crate directly, and if they need to, are assumed to be a Rust developer familiar with `cargo`.